### PR TITLE
Add support for configurable port forwarding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Requirements
 
 You need:
 
-* basic vagrant knowledge (RFTM skills are sufficient)
+* basic vagrant knowledge (RTFM skills are sufficient)
 * Vagrant >= 1.6.5 (``$ vagrant -v``)
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,8 +46,11 @@ Vagrant.configure('2') do |cfg|
       end
 
       # Networking
-      #config.vm.network :forwarded_port, guest: 22, host: 2222 #TODO make this configurable
-
+      forward_ports = get('ports', config_yaml, settings) || {}
+      forward_ports.each do |port|
+        config.vm.network :forwarded_port, guest: port['guest'], host:  port['host']
+      end
+                           
       if settings.has_key?('ip')
         config.vm.network 'private_network', ip: settings['ip']
       else


### PR DESCRIPTION
Add support for configurable port forwarding. When you have a section like these in your node.yaml

``` yaml

---
defaults:
  ...
  ports:
    - guest: 5050
      host: 5050
    - guest: 8080
      host: 8080
```

vagrant will forward the specified ports. At the moment this expects that a host and a guest port is set.
